### PR TITLE
Added setCustom method

### DIFF
--- a/namecheap.py
+++ b/namecheap.py
@@ -240,6 +240,19 @@ class Api(object):
 		})
 		self._call("namecheap.domains.dns.setHosts", extra_payload)
 
+	def domains_dns_setCustom(self, domain, host_records):
+		"""Sets the domain to use the supplied set of nameservers.
+
+		Example:
+
+		api.domains_dns_setCustom('example.com', { 'Nameservers' : 'ns1.example.com,ns2.example.com' })"""
+
+		extra_payload = host_records
+		sld, tld = domain.split(".")
+		extra_payload['SLD'] = sld
+		extra_payload['TLD'] = tld
+		self._call("namecheap.domains.dns.setCustom", extra_payload)
+
 	def domains_dns_getHosts(self, domain):
 		"""Retrieves DNS host record settings. Note that the key names are different from those
 		you use when setting the host records."""

--- a/namecheap_tests.py
+++ b/namecheap_tests.py
@@ -84,6 +84,15 @@ def test_domains_dns_setHosts():
 		}]
 	)
 
+#
+# I wasn't able to get this to work on any public name servers that I tried
+# including the ones used in their own example:
+#   dns1.name-servers.com
+#   dns2.name-server.com
+# Using my own Amazon Route53 name servers the test works fine but I didn't
+# want to embed my own servers
+# Adjust the name servers below to your own and uncomment the test to run
+
 #def test_domains_dns_setCustom():
 #	api = Api(username, api_key, username, ip_address, sandbox = True)
 #	domain_name = test_register_domain()

--- a/namecheap_tests.py
+++ b/namecheap_tests.py
@@ -84,6 +84,13 @@ def test_domains_dns_setHosts():
 		}]
 	)
 
+#def test_domains_dns_setCustom():
+#	api = Api(username, api_key, username, ip_address, sandbox = True)
+#	domain_name = test_register_domain()
+#	result = api.domains_dns_setCustom(
+#		domain_name, { 'Nameservers' : 'ns1.google.com,ns2.google.com' }
+#	)
+
 def test_domains_dns_getHosts():
 	api = Api(username, api_key, username, ip_address, sandbox = True)
 	domain_name = test_register_domain()


### PR DESCRIPTION
I had a need to move about 30 domains from Linode to AWS Route53.  Given that each domain on Route53 has a random setup of name servers I wanted to do this programatically.  I found it very useful perhaps some of your other users will as well.

Note: I couldn't get the test to work with domains name servers I didn't actually control.  The test is still there but commented out.