### PR TITLE
Add addHosts/delHosts methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,27 @@ The domains_check method returns True if the domain is available.
 You can also pass a list of domain names, in which case it does a batch check for all and returns a dictionary of the answers.
 You should probably not be writing a mass domain checking tool using this, it is intended to be used before registering a domain.
 
-### Basic host records management
+### CLI tool usage
+
+First, you need to edit `./credentials.py` file to provide API access for the script. The example is following:
+
+    #!/usr/bin/env python
+
+    api_key = '0123456789abcdef0123456789abcdef'
+    username = 'myusername'
+    ip_address = '10.0.0.1'
+
+Then you just call the script with desired arguments:
+
+    ./namecheap-api-cli --domain example.org --list
+
+    ./namecheap-api-cli --domain example.org --add --type "A" --name "test" --address "127.0.0.1" --ttl 300
+    ./namecheap-api-cli --domain example.org --add --type "CNAME" --name "alias-of-test" --address "test.example.org." --ttl 1800
+
+    ./namecheap-api-cli --domain example.org --delete --type "CNAME" --name "alias-of-test" --address "test.example.org."
+    ./namecheap-api-cli --domain example.org --delete --type "A" --name "test" --address "127.0.0.1"
+
+### Basic host records management code
 
 Here's the example of simple DNS records management script:
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,44 @@ The domains_check method returns True if the domain is available.
 You can also pass a list of domain names, in which case it does a batch check for all and returns a dictionary of the answers.
 You should probably not be writing a mass domain checking tool using this, it is intended to be used before registering a domain.
 
+### Basic host records management
+
+Here's the example of simple DNS records management script:
+
+    #!/usr/bin/env python
+
+    """
+    Define variables regarding to your API account:
+      - api_key
+      - username
+      - ip_address
+    """
+
+    api = Api(username, api_key, username, ip_address, sandbox=False)
+
+    domain = "example.org"
+
+    # list domain records
+    api.domains_dns_getHosts(domain)
+
+    record = {
+        # required
+        "Type": "A",
+        "Name": "test1",
+        "Address": "127.0.0.1",
+
+        # optional
+        "TTL": "1800",
+        "MXPref": "10"
+    }
+
+    # add A "test1" record pointing to 127.0.0.1
+    api.domains_dns_addHost(domain, record)
+
+    # delete record we just created,
+    # selecting it by Name, Type and Address values
+    api.domains_dns_delHost(domain, record)
+
 ### More
 
 Look at namecheap_tests.py to see more examples of things you can do.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@ Namecheap API for Python
 ===========
 
 PyNamecheap is a Namecheap API client in Python.
-API itself is documented at http://developer.namecheap.com/docs/
+API itself is documented at <http://developer.namecheap.com/docs/>
 
 This client supports:
- - Registering a domain
- - Checking domain name availability
- - Listing domains you have registered
- - Getting contact information for a domain
- - Setting DNS info to default values
- - Set DNS host records
+-   Registering a domain
+-   Checking domain name availability
+-   Listing domains you have registered
+-   Getting contact information for a domain
+-   Setting DNS info to default values
+-   Set DNS host records
 
 ### How to sign up to start using the API
 
-The API has two environments, production and sandbox. Since this API will spend real money when registering domains, start with the sandbox by going to http://www.sandbox.namecheap.com/ and creating an account. Accounts between production and sandbox are different, so even if you already have a Namecheap account you will need a new one.
+The API has two environments, production and sandbox. Since this API will spend real money when registering domains, start with the sandbox by going to <http://www.sandbox.namecheap.com/> and creating an account. Accounts between production and sandbox are different, so even if you already have a Namecheap account you will need a new one.
 
 After you have an account, go to "Profile".
 
@@ -32,7 +32,7 @@ You'll get to your credentials page. From here you need to take note of your api
 
 Copy namecheap.py to your project. In Python you can access the API as follows:
 
-	from namecheap import Api
+    from namecheap import Api
     api = Api(username, api_key, username, ip_address, sandbox = True)
 
 The fields are the ones which appear in the credentials screen above. The username appears twice, because you might be acting on behalf of someone else.
@@ -41,18 +41,18 @@ The fields are the ones which appear in the credentials screen above. The userna
 
 Unfortunately you need a bunch of contact details to register a domain, so it is not as easy as just providing the domain name. In the sandbox, the following contact details are acceptable. Trickiest field is the phone number, which has to be formatted as shown.
 
-	api.domains_create(
-		DomainName = 'registeringadomainthroughtheapiwow.com',
-		FirstName = 'Jack',
-		LastName = 'Trotter',
-		Address1 = 'Ridiculously Big Mansion, Yellow Brick Road',
-		City = 'Tokushima',
-		StateProvince = 'Tokushima',
-		PostalCode = '771-0144',
-		Country = 'Japan',
-		Phone = '+81.123123123',
-		EmailAddress = 'jack.trotter@example.com'
-	)
+    api.domains_create(
+        DomainName = 'registeringadomainthroughtheapiwow.com',
+        FirstName = 'Jack',
+        LastName = 'Trotter',
+        Address1 = 'Ridiculously Big Mansion, Yellow Brick Road',
+        City = 'Tokushima',
+        StateProvince = 'Tokushima',
+        PostalCode = '771-0144',
+        Country = 'Japan',
+        Phone = '+81.123123123',
+        EmailAddress = 'jack.trotter@example.com'
+    )
 
 This call should succeed in the sandbox, but if you use the API to check whether this domain is available after registering it, the availability will not change. This is normal.
 

--- a/namecheap-api-cli
+++ b/namecheap-api-cli
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import argparse
+import yaml
+
+from namecheap import Api, ApiError
+
+try:
+    from credentials import api_key, username, ip_address
+except:
+    pass
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="CLI tool to manage NameCheap.com domain records")
+
+    parser.add_argument("--debug", action="store_true", help="If set, enables debug output")
+    parser.add_argument("--sandbox", action="store_true", help="If set, forcing usage of Sandbox API, see README.md for details")
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--add", action="store_true", help="Use to add a record")
+    group.add_argument("--delete", action="store_true", help="Use to remove a record")
+    group.add_argument("--list", action="store_true", help="List existing records")
+
+    parser.add_argument("--domain", type=str, default="example.org", help="Domain to manage, default is \"example.org\", don't forget to override")
+
+    parser.add_argument("--type", type=str, default="A", help="Record type, default is \"A\"")
+    parser.add_argument("--name", type=str, default="test", help="Record name, default is \"test\"")
+    parser.add_argument("--address", type=str, default="127.0.0.1", help="Address for record to point to, default is \"127.0.0.1\"")
+    parser.add_argument("--ttl", type=int, default=300, help="Time-To-Live, in seconds, default is 300")
+
+    args = parser.parse_args()
+
+    return args
+
+
+def list_records():
+    return api.domains_dns_getHosts(domain)
+
+
+def record_delete(hostname, address, record_type="A", ttl=300):
+    record = {
+        "Type": record_type,
+        "Name": hostname,
+        "Address": address,
+        "TTL": str(ttl)
+    }
+    api.domains_dns_delHost(domain, record)
+
+
+def record_add(record_type, hostname, address, ttl=300):
+    record = {
+        "Type": record_type,
+        "Name": hostname,
+        "Address": address,
+        "TTL": str(ttl)
+    }
+    api.domains_dns_addHost(domain, record)
+
+args = get_args()
+
+domain = args.domain
+print("domain: %s" % domain)
+
+api = Api(username, api_key, username, ip_address, sandbox=args.sandbox, debug=args.debug)
+
+if args.add:
+    record_add(
+        args.type,
+        args.name,
+        args.address,
+        args.ttl
+    )
+
+if args.delete:
+    record_delete(
+        args.name,
+        args.address,
+        args.type
+    )
+
+if args.list:
+    for line in list_records():
+        print("\t%s \t%s\t%s -> %s" % (line["Type"], line["TTL"], line["Name"], line["Address"]))

--- a/namecheap.py
+++ b/namecheap.py
@@ -1,305 +1,311 @@
 import sys
-import requests # pip install requests
+import requests  # pip install requests
 from xml.etree.ElementTree import fromstring
 
 inPy3k = sys.version_info[0] == 3
 
 # http://developer.namecheap.com/docs/doku.php?id=overview:2.environments
 ENDPOINTS = {
-	# To use
-	# 1) browse to http://www.sandbox.namecheap.com/
-	# 2) create account, my account > manage profile > api access > enable API
-	# 3) add your IP address to whitelist
-	'sandbox' : 'https://api.sandbox.namecheap.com/xml.response',
-	'production' : 'https://api.namecheap.com/xml.response',
+    # To use
+    # 1) browse to http://www.sandbox.namecheap.com/
+    # 2) create account, my account > manage profile > api access > enable API
+    # 3) add your IP address to whitelist
+    'sandbox': 'https://api.sandbox.namecheap.com/xml.response',
+    'production': 'https://api.namecheap.com/xml.response',
 }
 NAMESPACE = "http://api.namecheap.com/xml.response"
 
+
 # https://www.namecheap.com/support/api/error-codes.aspx
 class ApiError(Exception):
-	def __init__(self, number, text):
-		Exception.__init__(self, '%s - %s' % (number, text))
-		self.number = number
-		self.text = text
+    def __init__(self, number, text):
+        Exception.__init__(self, '%s - %s' % (number, text))
+        self.number = number
+        self.text = text
+
 
 class Api(object):
-	# Follows API spec capitalization in variable names for consistency.
-	def __init__(self, ApiUser, ApiKey, UserName, ClientIP, sandbox = True, debug = True):
-		self.ApiUser = ApiUser
-		self.ApiKey = ApiKey
-		self.UserName = UserName
-		self.ClientIP = ClientIP
-		self.endpoint = ENDPOINTS['sandbox' if sandbox else 'production']
-		self.debug = debug
+    # Follows API spec capitalization in variable names for consistency.
+    def __init__(self, ApiUser, ApiKey, UserName, ClientIP, sandbox=True, debug=True):
+        self.ApiUser = ApiUser
+        self.ApiKey = ApiKey
+        self.UserName = UserName
+        self.ClientIP = ClientIP
+        self.endpoint = ENDPOINTS['sandbox' if sandbox else 'production']
+        self.debug = debug
 
-	# https://www.namecheap.com/support/api/methods/domains/create.aspx
-	def domains_create(self, DomainName, FirstName, LastName,
-		Address1, City, StateProvince, PostalCode, Country, Phone,
-		EmailAddress, Address2 = None, years = 1):
-		"""
-		Registers a domain name with the given contact info.
-		Example of a working phone number: +81.123123123
+    # https://www.namecheap.com/support/api/methods/domains/create.aspx
+    def domains_create(
+        self,
+        DomainName, FirstName, LastName,
+        Address1, City, StateProvince, PostalCode, Country, Phone,
+        EmailAddress, Address2=None, years=1
+    ):
+        """
+        Registers a domain name with the given contact info.
+        Example of a working phone number: +81.123123123
 
-		For simplicity assumes one person acts as all contact types."""
+        For simplicity assumes one person acts as all contact types."""
 
-		contact_types = ['Registrant', 'Tech', 'Admin', 'AuxBilling']
+        contact_types = ['Registrant', 'Tech', 'Admin', 'AuxBilling']
 
-		extra_payload = {
-			'DomainName' : DomainName,
-			'years' : years
-		}
+        extra_payload = {
+            'DomainName': DomainName,
+            'years': years
+        }
 
-		for contact_type in contact_types:
-			extra_payload.update({
-				'%sFirstName' % contact_type : FirstName,
-				'%sLastName' % contact_type : LastName,
-				'%sAddress1' % contact_type : Address1,
-				'%sCity' % contact_type : City,
-				'%sStateProvince' % contact_type : StateProvince,
-				'%sPostalCode' % contact_type : PostalCode,
-				'%sCountry' % contact_type : Country,
-				'%sPhone' % contact_type : Phone,
-				'%sEmailAddress' % contact_type : EmailAddress,
-			})
-			if Address2:
-				extra_payload['%sAddress2' % contact_type] = Address2
+        for contact_type in contact_types:
+            extra_payload.update({
+                '%sFirstName' % contact_type: FirstName,
+                '%sLastName' % contact_type: LastName,
+                '%sAddress1' % contact_type: Address1,
+                '%sCity' % contact_type: City,
+                '%sStateProvince' % contact_type: StateProvince,
+                '%sPostalCode' % contact_type: PostalCode,
+                '%sCountry' % contact_type: Country,
+                '%sPhone' % contact_type: Phone,
+                '%sEmailAddress' % contact_type: EmailAddress,
+            })
+            if Address2:
+                extra_payload['%sAddress2' % contact_type] = Address2
 
-		self._call('namecheap.domains.create', extra_payload)
+        self._call('namecheap.domains.create', extra_payload)
 
-	def _payload(self, Command, extra_payload = {}):
-		"""Make dictionary for passing to requests.get"""
-		payload = {
-			'ApiUser' : self.ApiUser,
-			'ApiKey' : self.ApiKey,
-			'UserName' : self.UserName,
-			'ClientIP' : self.ClientIP,
-			'Command' : Command,
-		}
-		payload.update(extra_payload)
-		return payload
+    def _payload(self, Command, extra_payload={}):
+        """Make dictionary for passing to requests.get"""
+        payload = {
+            'ApiUser': self.ApiUser,
+            'ApiKey': self.ApiKey,
+            'UserName': self.UserName,
+            'ClientIP': self.ClientIP,
+            'Command': Command,
+        }
+        payload.update(extra_payload)
+        return payload
 
-	def _fetch_xml(self, payload):
-		"""Make network call and return parsed XML element"""
-		r = requests.post(self.endpoint, params=payload)
-		if self.debug:
-			print("--- Request ---")
-			print(r.url)
-			print("--- Response ---")
-			print(r.text)
-		xml = fromstring(r.text)
+    def _fetch_xml(self, payload):
+        """Make network call and return parsed XML element"""
+        r = requests.post(self.endpoint, params=payload)
+        if self.debug:
+            print("--- Request ---")
+            print(r.url)
+            print("--- Response ---")
+            print(r.text)
+        xml = fromstring(r.text)
 
-		if xml.attrib['Status'] == 'ERROR':
-			# Response namespace must be prepended to tag names.
-			xpath = './/{%(ns)s}Errors/{%(ns)s}Error' % {'ns' : NAMESPACE}
-			error = xml.find(xpath)
-			raise ApiError(error.attrib['Number'], error.text)
+        if xml.attrib['Status'] == 'ERROR':
+            # Response namespace must be prepended to tag names.
+            xpath = './/{%(ns)s}Errors/{%(ns)s}Error' % {'ns': NAMESPACE}
+            error = xml.find(xpath)
+            raise ApiError(error.attrib['Number'], error.text)
 
-		return xml
+        return xml
 
-	def _call(self, Command, extra_payload = {}):
-		"""Call an API command"""
-		payload = self._payload(Command, extra_payload)
-		xml = self._fetch_xml(payload)
-		return xml
+    def _call(self, Command, extra_payload={}):
+        """Call an API command"""
+        payload = self._payload(Command, extra_payload)
+        xml = self._fetch_xml(payload)
+        return xml
 
-	class LazyGetListIterator(object):
-		"""When listing domain names, only one page is returned
-		initially. The list needs to be paged through to see all.
-		This iterator gets the next page when necessary."""
-		def _get_more_results(self):
-			xml = self.api._fetch_xml(self.payload)
-			xpath = './/{%(ns)s}CommandResponse/{%(ns)s}DomainGetListResult/{%(ns)s}Domain' % {'ns' : NAMESPACE}
-			domains = xml.findall(xpath)
-			for domain in domains:
-				self.results.append(domain.attrib)
-			self.payload['Page'] += 1
+    class LazyGetListIterator(object):
+        """When listing domain names, only one page is returned
+        initially. The list needs to be paged through to see all.
+        This iterator gets the next page when necessary."""
+        def _get_more_results(self):
+            xml = self.api._fetch_xml(self.payload)
+            xpath = './/{%(ns)s}CommandResponse/{%(ns)s}DomainGetListResult/{%(ns)s}Domain' % {'ns': NAMESPACE}
+            domains = xml.findall(xpath)
+            for domain in domains:
+                self.results.append(domain.attrib)
+            self.payload['Page'] += 1
 
-		def __init__(self, api, payload):
-			self.api = api
-			self.payload = payload
-			self.results = []
-			self.i = -1
+        def __init__(self, api, payload):
+            self.api = api
+            self.payload = payload
+            self.results = []
+            self.i = -1
 
-		def __iter__(self):
-			return self
+        def __iter__(self):
+            return self
 
-		def next(self):
-			self.i += 1
-			if self.i >= len(self.results):
-				self._get_more_results()
+        def next(self):
+            self.i += 1
+            if self.i >= len(self.results):
+                self._get_more_results()
 
-			if self.i >= len(self.results):
-				raise StopIteration
-			else:
-				return self.results[self.i]
+            if self.i >= len(self.results):
+                raise StopIteration
+            else:
+                return self.results[self.i]
 
-	# https://www.namecheap.com/support/api/methods/domains-dns/set-default.aspx
-	def domains_dns_setDefault(self, domain):
-		sld, tld = domain.split(".")
-		self._call("namecheap.domains.dns.setDefault", {
-			'SLD' : sld,
-			'TLD' : tld
-		})
+    # https://www.namecheap.com/support/api/methods/domains-dns/set-default.aspx
+    def domains_dns_setDefault(self, domain):
+        sld, tld = domain.split(".")
+        self._call("namecheap.domains.dns.setDefault", {
+            'SLD': sld,
+            'TLD': tld
+        })
 
-	# https://www.namecheap.com/support/api/methods/domains/check.aspx
-	def domains_check(self, domains):
-		"""Checks the availability of domains.
+    # https://www.namecheap.com/support/api/methods/domains/check.aspx
+    def domains_check(self, domains):
+        """Checks the availability of domains.
 
-		For example
-		api.domains_check(['taken.com', 'apsdjcpoaskdc.com'])
+        For example
+        api.domains_check(['taken.com', 'apsdjcpoaskdc.com'])
 
-		Might result in
-		{
-			'taken.com' : False,
-			'apsdjcpoaskdc.com' : True
-		}
-		"""
+        Might result in
+        {
+            'taken.com' : False,
+            'apsdjcpoaskdc.com' : True
+        }
+        """
 
-		# For convenience, allow a single domain to be given
-		if not inPy3k:
-			if isinstance(domains, basestring):
-				return self.domains_check([domains]).items()[0][1]
-		else:
-			if isinstance(domains, str):
-				return list(self.domains_check([domains]).items())[0][1]
+        # For convenience, allow a single domain to be given
+        if not inPy3k:
+            if isinstance(domains, basestring):
+                return self.domains_check([domains]).items()[0][1]
+        else:
+            if isinstance(domains, str):
+                return list(self.domains_check([domains]).items())[0][1]
 
-		extra_payload = {'DomainList' : ",".join(domains)}
-		xml = self._call('namecheap.domains.check', extra_payload)
-		xpath = './/{%(ns)s}CommandResponse/{%(ns)s}DomainCheckResult' % {'ns' : NAMESPACE}
-		results = {}
-		for check_result in xml.findall(xpath):
-			results[check_result.attrib['Domain']] = check_result.attrib['Available'] == 'true'
-		return results
+        extra_payload = {'DomainList': ",".join(domains)}
+        xml = self._call('namecheap.domains.check', extra_payload)
+        xpath = './/{%(ns)s}CommandResponse/{%(ns)s}DomainCheckResult' % {'ns': NAMESPACE}
+        results = {}
+        for check_result in xml.findall(xpath):
+            results[check_result.attrib['Domain']] = check_result.attrib['Available'] == 'true'
+        return results
 
-	@classmethod
-	def _tag_without_namespace(cls, element):
-		return element.tag.replace("{%s}" % NAMESPACE, "")
+    @classmethod
+    def _tag_without_namespace(cls, element):
+        return element.tag.replace("{%s}" % NAMESPACE, "")
 
-	@classmethod
-	def _list_of_dictionaries_to_numbered_payload(cls, l):
-		"""
-		[
-			{'foo' : 'bar', 'cat' : 'purr'},
-			{'foo' : 'buz'},
-			{'cat' : 'meow'}
-		]
+    @classmethod
+    def _list_of_dictionaries_to_numbered_payload(cls, l):
+        """
+        [
+            {'foo' : 'bar', 'cat' : 'purr'},
+            {'foo' : 'buz'},
+            {'cat' : 'meow'}
+        ]
 
-		becomes
+        becomes
 
-		{
-			'foo1' : 'bar',
-			'cat1' : 'purr',
-			'foo2' : 'buz',
-			'cat3' : 'meow'
-		}
-		"""
-		return dict(sum([
-			[(k+str(i+1),v) for k,v in d.items()] \
-			for i,d in enumerate(l)
-		], []))
+        {
+            'foo1' : 'bar',
+            'cat1' : 'purr',
+            'foo2' : 'buz',
+            'cat3' : 'meow'
+        }
+        """
+        return dict(sum([
+            [(k + str(i + 1), v) for k, v in d.items()] for i, d in enumerate(l)
+        ], []))
 
-#y = [dict([(k+str(i+1),v) for k,v in d.items()]) for i,d in enumerate(l)]
+    # https://www.namecheap.com/support/api/methods/domains/get-contacts.aspx
+    def domains_getContacts(self, DomainName):
+        """Gets contact information for the requested domain.
+        There are many categories of contact info, such as admin and billing.
 
-	# https://www.namecheap.com/support/api/methods/domains/get-contacts.aspx
-	def domains_getContacts(self, DomainName):
-		"""Gets contact information for the requested domain.
-		There are many categories of contact info, such as admin and billing.
+        The returned data is like:
+        {
+            'Admin' : {'FirstName' : 'John', 'LastName' : 'Connor', ...},
+            'Registrant' : {'FirstName' : 'Namecheap.com', 'PhoneExt' : None, ...},
+            ...
+        }
+        """
+        xml = self._call('namecheap.domains.getContacts', {'DomainName': DomainName})
+        xpath = './/{%(ns)s}CommandResponse/{%(ns)s}DomainContactsResult/*' % {'ns': NAMESPACE}
+        results = {}
+        for contact_type in xml.findall(xpath):
+            fields_for_one_contact_type = {}
+            for contact_detail in contact_type.findall('*'):
+                fields_for_one_contact_type[self._tag_without_namespace(contact_detail)] = contact_detail.text
+            results[self._tag_without_namespace(contact_type)] = fields_for_one_contact_type
+        return results
 
-		The returned data is like:
-		{
-			'Admin' : {'FirstName' : 'John', 'LastName' : 'Connor', ...},
-			'Registrant' : {'FirstName' : 'Namecheap.com', 'PhoneExt' : None, ...},
-			...
-		}
-		"""
-		xml = self._call('namecheap.domains.getContacts', {'DomainName' : DomainName})
-		xpath = './/{%(ns)s}CommandResponse/{%(ns)s}DomainContactsResult/*' % {'ns' : NAMESPACE}
-		results = {}
-		for contact_type in xml.findall(xpath):
-			fields_for_one_contact_type = {}
-			for contact_detail in contact_type.findall('*'):
-				fields_for_one_contact_type[self._tag_without_namespace(contact_detail)] = contact_detail.text
-			results[self._tag_without_namespace(contact_type)] = fields_for_one_contact_type
-		return results
+    # https://www.namecheap.com/support/api/methods/domains-dns/set-hosts.aspx
+    def domains_dns_setHosts(self, domain, host_records):
+        """Sets the DNS host records for a domain.
 
-	# https://www.namecheap.com/support/api/methods/domains-dns/set-hosts.aspx
-	def domains_dns_setHosts(self, domain, host_records):
-		"""Sets the DNS host records for a domain.
+        Example:
 
-		Example:
+        api.domains_dns_setHosts('example.com', [
+            {
+                'HostName' : '@',
+                'RecordType' : 'URL',
+                'Address' : 'http://news.ycombinator.com',
+                'MXPref' : '10',
+                'TTL' : '100'
+            }
+        ])"""
 
-		api.domains_dns_setHosts('example.com', [
-			{
-				'HostName' : '@',
-				'RecordType' : 'URL',
-				'Address' : 'http://news.ycombinator.com',
-				'MXPref' : '10',
-				'TTL' : '100'
-			}
-		])"""
+        extra_payload = self._list_of_dictionaries_to_numbered_payload(host_records)
+        sld, tld = domain.split(".")
+        extra_payload.update({
+            'SLD': sld,
+            'TLD': tld
+        })
+        self._call("namecheap.domains.dns.setHosts", extra_payload)
 
-		extra_payload = self._list_of_dictionaries_to_numbered_payload(host_records)
-		sld, tld = domain.split(".")
-		extra_payload.update({
-			'SLD' : sld,
-			'TLD' : tld
-		})
-		self._call("namecheap.domains.dns.setHosts", extra_payload)
+    # https://www.namecheap.com/support/api/methods/domains-dns/set-custom.aspx
+    def domains_dns_setCustom(self, domain, host_records):
+        """Sets the domain to use the supplied set of nameservers.
 
-	# https://www.namecheap.com/support/api/methods/domains-dns/set-custom.aspx
-	def domains_dns_setCustom(self, domain, host_records):
-		"""Sets the domain to use the supplied set of nameservers.
+        Example:
 
-		Example:
+        api.domains_dns_setCustom('example.com', { 'Nameservers' : 'ns1.example.com,ns2.example.com' })"""
 
-		api.domains_dns_setCustom('example.com', { 'Nameservers' : 'ns1.example.com,ns2.example.com' })"""
+        extra_payload = host_records
+        sld, tld = domain.split(".")
+        extra_payload['SLD'] = sld
+        extra_payload['TLD'] = tld
+        self._call("namecheap.domains.dns.setCustom", extra_payload)
 
-		extra_payload = host_records
-		sld, tld = domain.split(".")
-		extra_payload['SLD'] = sld
-		extra_payload['TLD'] = tld
-		self._call("namecheap.domains.dns.setCustom", extra_payload)
+    # https://www.namecheap.com/support/api/methods/domains-dns/get-hosts.aspx
+    def domains_dns_getHosts(self, domain):
+        """Retrieves DNS host record settings. Note that the key names are different from those
+        you use when setting the host records."""
+        sld, tld = domain.split(".")
+        extra_payload = {
+            'SLD': sld,
+            'TLD': tld
+        }
+        xml = self._call("namecheap.domains.dns.getHosts", extra_payload)
+        xpath = './/{%(ns)s}CommandResponse/{%(ns)s}DomainDNSGetHostsResult/*' % {'ns': NAMESPACE}
+        results = []
+        for host in xml.findall(xpath):
+            results.append(host.attrib)
+        return results
 
-	# https://www.namecheap.com/support/api/methods/domains-dns/get-hosts.aspx
-	def domains_dns_getHosts(self, domain):
-		"""Retrieves DNS host record settings. Note that the key names are different from those
-		you use when setting the host records."""
-		sld, tld = domain.split(".")
-		extra_payload = {
-			'SLD' : sld,
-			'TLD' : tld
-		}
-		xml = self._call("namecheap.domains.dns.getHosts", extra_payload)
-		xpath = './/{%(ns)s}CommandResponse/{%(ns)s}DomainDNSGetHostsResult/*' % {'ns' : NAMESPACE}
-		results = []
-		for host in xml.findall(xpath):
-			results.append(host.attrib)
-		return results
+    # https://www.namecheap.com/support/api/methods/domains-dns/get-list.aspx
+    def domains_getList(self, ListType=None, SearchTerm=None, PageSize=None, SortBy=None):
+        """Returns an iterable of dicts. Each dict represents one
+        domain name the user has registered, for example
+        {
+            'Name': 'coolestfriends.com',
+            'Created': '04/11/2012',
+            'Expires': '04/11/2018',
+            'ID': '8385859',
+            'AutoRenew': 'false',
+            'IsLocked': 'false',
+            'User': 'Bemmu',
+            'IsExpired': 'false',
+            'WhoisGuard': 'NOTPRESENT'
+        }
+        """
 
-	# https://www.namecheap.com/support/api/methods/domains-dns/get-list.aspx
-	def domains_getList(self, ListType = None, SearchTerm = None, PageSize = None, SortBy = None):
-		"""Returns an iterable of dicts. Each dict represents one
-		domain name the user has registered, for example
-		{
-			'Name': 'coolestfriends.com',
-			'Created': '04/11/2012',
-			'Expires': '04/11/2018',
-			'ID': '8385859',
-			'AutoRenew': 'false',
-			'IsLocked': 'false',
-			'User': 'Bemmu',
-			'IsExpired': 'false',
-			'WhoisGuard': 'NOTPRESENT'
-		}
-		"""
-
-		# The payload is a dict of GET args that is passed to
-		# the lazy-loading iterator so that it can know how to
-		# get more results.
-		extra_payload = {'Page' : 1}
-		if ListType: extra_payload['ListType'] = ListType
-		if SearchTerm: extra_payload['SearchTerm'] = SearchTerm
-		if PageSize: extra_payload['PageSize'] = PageSize
-		if SortBy: extra_payload['SortBy'] = SortBy
-		payload = self._payload('namecheap.domains.getList', extra_payload)
-		return self.LazyGetListIterator(self, payload)
+        # The payload is a dict of GET args that is passed to
+        # the lazy-loading iterator so that it can know how to
+        # get more results.
+        extra_payload = {'Page': 1}
+        if ListType:
+            extra_payload['ListType'] = ListType
+        if SearchTerm:
+            extra_payload['SearchTerm'] = SearchTerm
+        if PageSize:
+            extra_payload['PageSize'] = PageSize
+        if SortBy:
+            extra_payload['SortBy'] = SortBy
+        payload = self._payload('namecheap.domains.getList', extra_payload)
+        return self.LazyGetListIterator(self, payload)

--- a/namecheap_tests.py
+++ b/namecheap_tests.py
@@ -1,88 +1,98 @@
 # Run "nosetests" on command line to run these.
 from namecheap import Api, ApiError
-from nose.tools import * # pip install nose
+from nose.tools import *  # pip install nose
 
-api_key = '' # You create this on Namecheap site
+api_key = ''  # You create this on Namecheap site
 username = ''
-ip_address = '' # Your IP address that you whitelisted on the site
+ip_address = ''  # Your IP address that you whitelisted on the site
 
 # If you prefer, you can put the above in credentials.py instead
 try:
-	from credentials import api_key, username, ip_address
+    from credentials import api_key, username, ip_address
 except:
-	pass
+    pass
+
 
 def random_domain_name():
-	import random, time
-	domain_name = "%s%s.com" % (int(time.time()), random.randint(0,10**16))
-	return domain_name
+    import random
+    import time
+    domain_name = "%s%s.com" % (int(time.time()), random.randint(0, 10**16))
+    return domain_name
+
 
 def test_domain_taken():
-	api = Api(username, api_key, username, ip_address, sandbox = True)
-	domain_name = "google.com"
-	assert_equal(api.domains_check(domain_name), False)
+    api = Api(username, api_key, username, ip_address, sandbox=True)
+    domain_name = "google.com"
+    assert_equal(api.domains_check(domain_name), False)
+
 
 def test_domain_available():
-	api = Api(username, api_key, username, ip_address, sandbox = True)
-	domain_name = random_domain_name()
-	assert_equal(api.domains_check(domain_name), True)
+    api = Api(username, api_key, username, ip_address, sandbox=True)
+    domain_name = random_domain_name()
+    assert_equal(api.domains_check(domain_name), True)
+
 
 def test_register_domain():
-	api = Api(username, api_key, username, ip_address, sandbox = True)
+    api = Api(username, api_key, username, ip_address, sandbox=True)
 
-	# Try registering a random domain. Fails if exception raised.
-	domain_name = random_domain_name()
-	api.domains_create(
-		DomainName = domain_name,
-		FirstName = 'Jack',
-		LastName = 'Trotter',
-		Address1 = 'Ridiculously Big Mansion, Yellow Brick Road',
-		City = 'Tokushima',
-		StateProvince = 'Tokushima',
-		PostalCode = '771-0144',
-		Country = 'Japan',
-		Phone = '+81.123123123',
-		EmailAddress = 'jack.trotter@example.com'
-	)
-	return domain_name
+    # Try registering a random domain. Fails if exception raised.
+    domain_name = random_domain_name()
+    api.domains_create(
+        DomainName=domain_name,
+        FirstName='Jack',
+        LastName='Trotter',
+        Address1='Ridiculously Big Mansion, Yellow Brick Road',
+        City='Tokushima',
+        StateProvince='Tokushima',
+        PostalCode='771-0144',
+        Country='Japan',
+        Phone='+81.123123123',
+        EmailAddress='jack.trotter@example.com'
+    )
+    return domain_name
+
 
 def test_domains_getList():
-	api = Api(username, api_key, username, ip_address, sandbox = True)
-	api.domains_getList()
+    api = Api(username, api_key, username, ip_address, sandbox=True)
+    api.domains_getList()
+
 
 @raises(ApiError)
 def test_domains_dns_setDefault_on_nonexisting_domain():
-	api = Api(username, api_key, username, ip_address, sandbox = True)
+    api = Api(username, api_key, username, ip_address, sandbox=True)
 
-	domain_name = random_domain_name()
+    domain_name = random_domain_name()
 
-	# This should fail because the domain does not exist
-	api.domains_dns_setDefault(domain_name)	
+    # This should fail because the domain does not exist
+    api.domains_dns_setDefault(domain_name)
+
 
 def test_domains_dns_setDefault_on_existing_domain():
-	api = Api(username, api_key, username, ip_address, sandbox = True)
-	domain_name = test_register_domain()
-	api.domains_dns_setDefault(domain_name)	
+    api = Api(username, api_key, username, ip_address, sandbox=True)
+    domain_name = test_register_domain()
+    api.domains_dns_setDefault(domain_name)
+
 
 def test_domains_getContacts():
-	# How would I test for this? This needs a known registered
-	# domain to get the contact info for, but in sandbox won't
-	# have any.
-	pass
+    # How would I test for this? This needs a known registered
+    # domain to get the contact info for, but in sandbox won't
+    # have any.
+    pass
+
 
 def test_domains_dns_setHosts():
-	api = Api(username, api_key, username, ip_address, sandbox = True)
-	domain_name = test_register_domain()
-	api.domains_dns_setHosts(
-		domain_name,
-		[{
-			'HostName' : '@',
-			'RecordType' : 'URL',
-			'Address' : 'http://news.ycombinator.com',
-			'MXPref' : '10',
-			'TTL' : '100'
-		}]
-	)
+    api = Api(username, api_key, username, ip_address, sandbox=True)
+    domain_name = test_register_domain()
+    api.domains_dns_setHosts(
+        domain_name,
+        [{
+            'HostName': '@',
+            'RecordType': 'URL',
+            'Address': 'http://news.ycombinator.com',
+            'MXPref': '10',
+            'TTL': '100'
+        }]
+    )
 
 #
 # I wasn't able to get this to work on any public name servers that I tried
@@ -93,57 +103,129 @@ def test_domains_dns_setHosts():
 # want to embed my own servers
 # Adjust the name servers below to your own and uncomment the test to run
 
-#def test_domains_dns_setCustom():
-#	api = Api(username, api_key, username, ip_address, sandbox = True)
-#	domain_name = test_register_domain()
-#	result = api.domains_dns_setCustom(
-#		domain_name, { 'Nameservers' : 'ns1.google.com,ns2.google.com' }
-#	)
+# def test_domains_dns_setCustom():
+#    api = Api(username, api_key, username, ip_address, sandbox=True)
+#    domain_name = test_register_domain()
+#    result = api.domains_dns_setCustom(
+#        domain_name, { 'Nameservers' : 'ns1.google.com,ns2.google.com' }
+#    )
+
 
 def test_domains_dns_getHosts():
-	api = Api(username, api_key, username, ip_address, sandbox = True)
-	domain_name = test_register_domain()
-	api.domains_dns_setHosts(
-		domain_name,
-		[{
-			'HostName' : '@',
-			'RecordType' : 'URL',
-			'Address' : 'http://news.ycombinator.com',
-			'MXPref' : '10',
-			'TTL' : '100'
-		},
-		{
-			'HostName' : '*',
-			'RecordType' : 'A',
-			'Address' : '1.2.3.4',
-			'MXPref' : '10',
-			'TTL' : '1800'
-		}]
-	)
+    api = Api(username, api_key, username, ip_address, sandbox=True)
+    domain_name = test_register_domain()
+    api.domains_dns_setHosts(
+        domain_name,
+        [{
+            'HostName': '@',
+            'RecordType': 'URL',
+            'Address': 'http://news.ycombinator.com',
+            'MXPref': '10',
+            'TTL': '100'
+        }, {
+            'HostName': '*',
+            'RecordType': 'A',
+            'Address': '1.2.3.4',
+            'MXPref': '10',
+            'TTL': '1800'
+        }]
+    )
 
-	hosts = api.domains_dns_getHosts(domain_name)
+    hosts = api.domains_dns_getHosts(domain_name)
 
-	# these might change
-	del hosts[0]['HostId'] 
-	del hosts[1]['HostId'] 
+    # these might change
+    del hosts[0]['HostId']
+    del hosts[1]['HostId']
 
-	expected_result = [{'Name': '*', 'Address': '1.2.3.4', 'TTL': '1800', 'Type': 'A', 'MXPref': '10', 'AssociatedAppTitle': '', 'FriendlyName': '', 'IsActive': ''}, {'Name': '@', 'Address': 'http://news.ycombinator.com', 'TTL': '100', 'Type': 'URL', 'MXPref': '10', 'AssociatedAppTitle': '', 'FriendlyName': '', 'IsActive': ''}]
-	assert_equal(hosts, expected_result)
+    expected_result = [{'Name': '*', 'Address': '1.2.3.4', 'TTL': '1800', 'Type': 'A', 'MXPref': '10', 'AssociatedAppTitle': '', 'FriendlyName': '', 'IsActive': ''}, {'Name': '@', 'Address': 'http://news.ycombinator.com', 'TTL': '100', 'Type': 'URL', 'MXPref': '10', 'AssociatedAppTitle': '', 'FriendlyName': '', 'IsActive': ''}]
+    assert_equal(hosts, expected_result)
+
+
+def test_domains_dns_addHost():
+    api = Api(username, api_key, username, ip_address, sandbox=True)
+    domain_name = test_register_domain()
+    api.domains_dns_setHosts(
+        domain_name,
+        [{
+            'HostName': '@',
+            'RecordType': 'URL',
+            'Address': 'http://news.ycombinator.com',
+            'MXPref': '10',
+            'TTL': '100'
+        }]
+    )
+    api.domains_dns_addHost(
+        domain_name,
+        {
+            'HostName': '*',
+            'RecordType': 'A',
+            'Address': '1.2.3.4',
+            'MXPref': '10',
+            'TTL': '1800'
+        }
+    )
+
+    hosts = api.domains_dns_getHosts(domain_name)
+
+    # these might change
+    del hosts[0]['HostId']
+    del hosts[1]['HostId']
+
+    expected_result = [{'Name': '*', 'Address': '1.2.3.4', 'TTL': '1800', 'Type': 'A', 'MXPref': '10', 'AssociatedAppTitle': '', 'FriendlyName': '', 'IsActive': ''}, {'Name': '@', 'Address': 'http://news.ycombinator.com', 'TTL': '100', 'Type': 'URL', 'MXPref': '10', 'AssociatedAppTitle': '', 'FriendlyName': '', 'IsActive': ''}]
+    assert_equal(hosts, expected_result)
+
+
+def test_domains_dns_delHost():
+    api = Api(username, api_key, username, ip_address, sandbox=True)
+    domain_name = test_register_domain()
+    api.domains_dns_setHosts(
+        domain_name,
+        [{
+            'HostName': '@',
+            'RecordType': 'URL',
+            'Address': 'http://news.ycombinator.com',
+            'MXPref': '10',
+            'TTL': '100'
+        }, {
+            'HostName': '*',
+            'RecordType': 'A',
+            'Address': '1.2.3.4',
+            'MXPref': '10',
+            'TTL': '1800'
+        }]
+    )
+    api.domains_dns_delHost(
+        domain_name,
+        {
+            'HostName': '*',
+            'RecordType': 'A',
+            'Address': '1.2.3.4'
+        }
+    )
+
+    hosts = api.domains_dns_getHosts(domain_name)
+
+    # these might change
+    del hosts[0]['HostId']
+
+    expected_result = [{'Name': '@', 'Address': 'http://news.ycombinator.com', 'TTL': '100', 'Type': 'URL', 'MXPref': '10', 'AssociatedAppTitle': '', 'FriendlyName': '', 'IsActive': ''}]
+    assert_equal(hosts, expected_result)
+
 
 def test_list_of_dictionaries_to_numbered_payload():
-	x = [
-		{'foo' : 'bar', 'cat' : 'purr'},
-		{'foo' : 'buz'},
-		{'cat' : 'meow'}
-	]
+    x = [
+        {'foo': 'bar', 'cat': 'purr'},
+        {'foo': 'buz'},
+        {'cat': 'meow'}
+    ]
 
-	result = Api._list_of_dictionaries_to_numbered_payload(x)
+    result = Api._list_of_dictionaries_to_numbered_payload(x)
 
-	expected_result = {
-		'foo1' : 'bar',
-		'cat1' : 'purr',
-		'foo2' : 'buz',
-		'cat3' : 'meow'
-	}
+    expected_result = {
+        'foo1': 'bar',
+        'cat1': 'purr',
+        'foo2': 'buz',
+        'cat3': 'meow'
+    }
 
-	assert_equal(result, expected_result)
+    assert_equal(result, expected_result)

--- a/namecheap_tests.py
+++ b/namecheap_tests.py
@@ -12,11 +12,10 @@ try:
 except:
     pass
 
-
 def random_domain_name():
     import random
-    import time
-    domain_name = "%s%s.com" % (int(time.time()), random.randint(0, 10**16))
+    from time import gmtime, strftime
+    domain_name = "%s-%s.com" % (strftime("%Y%m%d-%H%M%S", gmtime()), random.randint(0, 10**16))
     return domain_name
 
 
@@ -137,7 +136,29 @@ def test_domains_dns_getHosts():
     del hosts[0]['HostId']
     del hosts[1]['HostId']
 
-    expected_result = [{'Name': '*', 'Address': '1.2.3.4', 'TTL': '1800', 'Type': 'A', 'MXPref': '10', 'AssociatedAppTitle': '', 'FriendlyName': '', 'IsActive': ''}, {'Name': '@', 'Address': 'http://news.ycombinator.com', 'TTL': '100', 'Type': 'URL', 'MXPref': '10', 'AssociatedAppTitle': '', 'FriendlyName': '', 'IsActive': ''}]
+    expected_result = [
+        {
+            'Name': '*',
+            'Address': '1.2.3.4',
+            'TTL': '1800',
+            'Type': 'A',
+            'MXPref': '10',
+            'AssociatedAppTitle': '',
+            'FriendlyName': '',
+            'IsActive': 'true',
+            'IsDDNSEnabled': 'false'
+        }, {
+            'Name': '@',
+            'Address': 'http://news.ycombinator.com',
+            'TTL': '100',
+            'Type': 'URL',
+            'MXPref': '10',
+            'AssociatedAppTitle': '',
+            'FriendlyName': '',
+            'IsActive': 'true',
+            'IsDDNSEnabled': 'false'
+        }
+    ]
     assert_equal(hosts, expected_result)
 
 
@@ -149,19 +170,16 @@ def test_domains_dns_addHost():
         [{
             'HostName': '@',
             'RecordType': 'URL',
-            'Address': 'http://news.ycombinator.com',
-            'MXPref': '10',
-            'TTL': '100'
+            'Address': 'http://news.ycombinator.com'
         }]
     )
     api.domains_dns_addHost(
         domain_name,
         {
-            'HostName': '*',
-            'RecordType': 'A',
+            'Name': 'test',
+            'Type': 'A',
             'Address': '1.2.3.4',
-            'MXPref': '10',
-            'TTL': '1800'
+            'TTL': '100'
         }
     )
 
@@ -171,7 +189,29 @@ def test_domains_dns_addHost():
     del hosts[0]['HostId']
     del hosts[1]['HostId']
 
-    expected_result = [{'Name': '*', 'Address': '1.2.3.4', 'TTL': '1800', 'Type': 'A', 'MXPref': '10', 'AssociatedAppTitle': '', 'FriendlyName': '', 'IsActive': ''}, {'Name': '@', 'Address': 'http://news.ycombinator.com', 'TTL': '100', 'Type': 'URL', 'MXPref': '10', 'AssociatedAppTitle': '', 'FriendlyName': '', 'IsActive': ''}]
+    expected_result = [
+        {
+            'Name': 'test',
+            'Address': '1.2.3.4',
+            'TTL': '100',
+            'Type': 'A',
+            'MXPref': '10',
+            'AssociatedAppTitle': '',
+            'FriendlyName': '',
+            'IsActive': 'true',
+            'IsDDNSEnabled': 'false'
+        }, {
+            'Name': '@',
+            'Address': 'http://news.ycombinator.com',
+            'TTL': '1800',
+            'Type': 'URL',
+            'MXPref': '10',
+            'AssociatedAppTitle': '',
+            'FriendlyName': '',
+            'IsActive': 'true',
+            'IsDDNSEnabled': 'false'
+        }
+    ]
     assert_equal(hosts, expected_result)
 
 
@@ -184,21 +224,18 @@ def test_domains_dns_delHost():
             'HostName': '@',
             'RecordType': 'URL',
             'Address': 'http://news.ycombinator.com',
-            'MXPref': '10',
-            'TTL': '100'
+            'TTL': '200'
         }, {
-            'HostName': '*',
+            'HostName': 'test',
             'RecordType': 'A',
-            'Address': '1.2.3.4',
-            'MXPref': '10',
-            'TTL': '1800'
+            'Address': '1.2.3.4'
         }]
     )
     api.domains_dns_delHost(
         domain_name,
         {
-            'HostName': '*',
-            'RecordType': 'A',
+            'Name': 'test',
+            'Type': 'A',
             'Address': '1.2.3.4'
         }
     )
@@ -208,7 +245,19 @@ def test_domains_dns_delHost():
     # these might change
     del hosts[0]['HostId']
 
-    expected_result = [{'Name': '@', 'Address': 'http://news.ycombinator.com', 'TTL': '100', 'Type': 'URL', 'MXPref': '10', 'AssociatedAppTitle': '', 'FriendlyName': '', 'IsActive': ''}]
+    expected_result = [
+        {
+            'Name': '@',
+            'Address': 'http://news.ycombinator.com',
+            'TTL': '200',
+            'Type': 'URL',
+            'MXPref': '10',
+            'AssociatedAppTitle': '',
+            'FriendlyName': '',
+            'IsActive': 'true',
+            'IsDDNSEnabled': 'false'
+        }
+    ]
     assert_equal(hosts, expected_result)
 
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+from namecheap import Api, ApiError
+
+try:
+    from credentials import api_key, username, ip_address
+except:
+    pass
+
+domain = "roxottech.com"
+api = Api(username, api_key, username, ip_address, sandbox=False)
+record = {
+    "Type": "A",
+    "Name": "test",
+    "Address": "127.0.0.1",
+    "TTL": 1800,
+    "MXPref": 10
+}
+api.domains_dns_addHost(domain, record)


### PR DESCRIPTION
Hello!

Let me thank you in public for such a simple yet great tool.

I updated the code, the changes are following:

- added `addHosts` and `delHosts` method, allowing to specify just the record to add, not the full list, as `setHosts` demands
- added internal `_elements_names_fix` method to allow use both `Name` / `HostName` and `Type` / `RecordType` filed name pairs
- updated tests accordingly
- updated `README.md` with basic usage examples of new methods

The reason files looks ~95% rewritten are pep8/markdown warnings:

- replaced tabs with 4x white-spaces
- replaced `def x(a = 1)` with `def x(a=1)`
- replaced `{ a: 5 }` with `{a: 5}`

In fact, only 2 stated methods were added.

Feel free to review the code and comment if you want me to rollback some changes I made.