### PR TITLE
Add setup.py to install from pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,12 @@ def read(fname):
 setup(
     name='namesilo',
     version='0.1.4',
-    url='http://github.com/kolanos/namesilo',
+    url='https://github.com/inomoz/PyNamecheap',
     license='MIT',
     author='Bemmu Sepponen',
     author_email='me@bemmu.com',
     description='Namecheap API client in Python',
-    py_modules=['PyNamecheap'],
+    py_modules=['namecheap'],
     platforms='any',
     install_requires=['requests'],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ def read(fname):
 
 setup(
     name='namecheap',
-    version='0.1.4',
-    url='https://github.com/inomoz/PyNamecheap',
+    version='0.0.1',
+    url='https://github.com/Bemmu/PyNamecheapp',
     license='MIT',
     author='Bemmu Sepponen',
     author_email='me@bemmu.com',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 
 
 setup(
-    name='namecheap',
+    name='PyNamecheap',
     version='0.0.1',
     url='https://github.com/Bemmu/PyNamecheapp',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 
 
 setup(
-    name='namesilo',
+    name='namecheap',
     version='0.1.4',
     url='https://github.com/inomoz/PyNamecheap',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+
+import os
+
+from setuptools import setup
+
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+
+setup(
+    name='namesilo',
+    version='0.1.4',
+    url='http://github.com/kolanos/namesilo',
+    license='MIT',
+    author='Bemmu Sepponen',
+    author_email='me@bemmu.com',
+    description='Namecheap API client in Python',
+    py_modules=['PyNamecheap'],
+    platforms='any',
+    install_requires=['requests'],
+    classifiers=[
+        'Environment :: Web Environment',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Topic :: Internet :: WWW/HTTP',
+        'Topic :: Software Development :: Libraries :: Python Modules'
+    ]
+)


### PR DESCRIPTION
Hi, I use pip to install packages, this line in requirements.txt worked for me (when I added setup.py, as base I used file from namesilo package).:
```
git+git://github.com/inomoz/PyNamecheap.git@master#egg=namecheap
```
You can also submit a package to PyPI.
http://peterdowns.com/posts/first-time-with-pypi.html

P.S. this PR not tested completely.