### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+setuptools>=39.2.0


### PR DESCRIPTION
setuptools is needed in setup.py, however not installed as a dependency in the project.