### PR TITLE
More params + user_payload for domains_create, add returns to method calls, add type annotations + more

### DIFF
--- a/namecheap_tests.py
+++ b/namecheap_tests.py
@@ -12,6 +12,11 @@ try:
 except:
     pass
 
+
+def is_true(val):
+    return val in ['true', True, 1, '1', 'yes', 'True', 'TRUE']
+
+
 def random_domain_name():
     import random
     from time import gmtime, strftime
@@ -36,7 +41,7 @@ def test_register_domain():
 
     # Try registering a random domain. Fails if exception raised.
     domain_name = random_domain_name()
-    api.domains_create(
+    res = api.domains_create(
         DomainName=domain_name,
         FirstName='Jack',
         LastName='Trotter',
@@ -48,6 +53,11 @@ def test_register_domain():
         Phone='+81.123123123',
         EmailAddress='jack.trotter@example.com'
     )
+    
+    assert_equal(res['Domain'], domain_name)
+    ok_(int(res['DomainID']) > 0)
+    ok_(int(res['TransactionID']) > 0)
+    ok_(is_true(res['Registered']))
     return domain_name
 
 
@@ -69,7 +79,9 @@ def test_domains_dns_setDefault_on_nonexisting_domain():
 def test_domains_dns_setDefault_on_existing_domain():
     api = Api(username, api_key, username, ip_address, sandbox=True)
     domain_name = test_register_domain()
-    api.domains_dns_setDefault(domain_name)
+    res = api.domains_dns_setDefault(domain_name)
+    assert_equal(res['Domain'], domain_name)
+    ok_(is_true(res['Updated']))
 
 
 def test_domains_getContacts():
@@ -82,7 +94,7 @@ def test_domains_getContacts():
 def test_domains_dns_setHosts():
     api = Api(username, api_key, username, ip_address, sandbox=True)
     domain_name = test_register_domain()
-    api.domains_dns_setHosts(
+    res = api.domains_dns_setHosts(
         domain_name,
         [{
             'HostName': '@',
@@ -92,6 +104,8 @@ def test_domains_dns_setHosts():
             'TTL': '100'
         }]
     )
+    assert_equal(res['Domain'], domain_name)
+    ok_(is_true(res['IsSuccess']))
 
 #
 # I wasn't able to get this to work on any public name servers that I tried
@@ -244,7 +258,8 @@ def test_domains_dns_bulkAddHosts():
 def test_domains_dns_delHost():
     api = Api(username, api_key, username, ip_address, sandbox=True)
     domain_name = test_register_domain()
-    api.domains_dns_setHosts(
+    
+    res = api.domains_dns_setHosts(
         domain_name,
         [{
             'HostName': '@',
@@ -257,7 +272,10 @@ def test_domains_dns_delHost():
             'Address': '1.2.3.4'
         }]
     )
-    api.domains_dns_delHost(
+    assert_equal(res['Domain'], domain_name)
+    ok_(is_true(res['IsSuccess']))
+    
+    res = api.domains_dns_delHost(
         domain_name,
         {
             'Name': 'test',
@@ -265,7 +283,9 @@ def test_domains_dns_delHost():
             'Address': '1.2.3.4'
         }
     )
-
+    assert_equal(res['Domain'], domain_name)
+    ok_(is_true(res['IsSuccess']))
+    
     hosts = api.domains_dns_getHosts(domain_name)
 
     # these might change

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 setuptools>=39.2.0
+requests
+nose


### PR DESCRIPTION
This pull request includes a wide variety of improvements and additions to PyNamecheap, which makes the library more IDE friendly (type annotations), and more flexible (user specifiable extra payload kwargs + return response data everywhere)

I have not touched the version in `setup.py` as I'm not a maintainer for PyNamecheap, and you may want to merge in multiple PRs to make up the 0.0.4 release.

I've noticed the main `namecheap.py` file hasn't been updated in several years, so **just in-case this project is abandoned,** we'll be maintaining and publishing our fork of this library here: https://github.com/Privex/PyNamecheap

----------------------

# Notable changes in this pull request

 - Added `OrganizationName`, `JobTitle`, `PromotionCode`, and `Nameservers` to `Api.domains_create`, which allow registering domains with a company, and allow setting nameservers immediately while purchasing a domain.

 - Added `**user_payload` to `Api.domains_create`, which allows users to specify custom payload keys that aren't yet implemented, or override payload keys which were auto-generated by the function (e.g. ``WGEnabled``, `RegistrantEmailAddress` etc.)

 - Added helper methods `get_element` and `get_element_dict` for working with XML objects

 - Added `self.get_element_dict()` return values to `domain_create`, `domains_dns_setDefault`, `domains_dns_setHosts`, `domains_dns_setCustom`, `domains_dns_addHost`, and `domains_dns_delHost`
    - This allows users of the library to be able to actually interpret the command response from Namecheap. While most commands just return the domain name and `IsSuccess` / `Updated` etc., some commands such as `domains_create` return a lot of useful data, such as the amount that the domain costed, IDs for the domain / transaction / order, whether WhoisGuard was enabled, whether or not a free PostiveSSL certificate was claimed etc.

 - Added type annotations to most `Api` methods. Used the Python 2.x / early 3.x compatible `# type: () -> xxx` format, as I'm unsure what versions of Python that PyNamecheap is aiming to support.

 - Updated `namecheap_tests.py` to validate the new `dict` return values from methods such as `domain_create`

 - Added `requests` and `nose` to `requirements.txt` to simplify dependency installation in a dev environment