### PR TITLE
Fix error adding MX records

### DIFF
--- a/namecheap-api-cli
+++ b/namecheap-api-cli
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import json
 
 from namecheap import Api, ApiError
 
@@ -11,22 +12,35 @@ except:
 
 
 def get_args():
-    parser = argparse.ArgumentParser(description="CLI tool to manage NameCheap.com domain records")
+    parser = argparse.ArgumentParser(
+        description="CLI tool to manage NameCheap.com domain records")
 
-    parser.add_argument("--debug", action="store_true", help="If set, enables debug output")
-    parser.add_argument("--sandbox", action="store_true", help="If set, forcing usage of Sandbox API, see README.md for details")
+    parser.add_argument("--debug", action="store_true",
+                        help="If set, enables debug output")
+    parser.add_argument("--sandbox", action="store_true",
+                        help="If set, forcing usage of Sandbox API, see README.md for details")
 
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--add", action="store_true", help="Use to add a record")
-    group.add_argument("--delete", action="store_true", help="Use to remove a record")
-    group.add_argument("--list", action="store_true", help="List existing records")
+    group.add_argument("--add", action="store_true",
+                       help="Use to add a record")
+    group.add_argument("--delete", action="store_true",
+                       help="Use to remove a record")
+    group.add_argument("--list", action="store_true",
+                       help="List existing records")
+    group.add_argument("--json", action="store_true",
+                       help="List existing records and return JSON list")
 
-    parser.add_argument("--domain", type=str, default="example.org", help="Domain to manage, default is \"example.org\", don't forget to override")
+    parser.add_argument("--domain", type=str, default="example.org",
+                        help="Domain to manage, default is \"example.org\", don't forget to override")
 
-    parser.add_argument("--type", type=str, default="A", help="Record type, default is \"A\"")
-    parser.add_argument("--name", type=str, default="test", help="Record name, default is \"test\"")
-    parser.add_argument("--address", type=str, default="127.0.0.1", help="Address for record to point to, default is \"127.0.0.1\"")
-    parser.add_argument("--ttl", type=int, default=300, help="Time-To-Live, in seconds, default is 300")
+    parser.add_argument("--type", type=str, default="A",
+                        help="Record type, default is \"A\"")
+    parser.add_argument("--name", type=str, default="test",
+                        help="Record name, default is \"test\"")
+    parser.add_argument("--address", type=str, default="127.0.0.1",
+                        help="Address for record to point to, default is \"127.0.0.1\"")
+    parser.add_argument("--ttl", type=int, default=300,
+                        help="Time-To-Live, in seconds, default is 300")
 
     args = parser.parse_args()
 
@@ -56,12 +70,13 @@ def record_add(record_type, hostname, address, ttl=300):
     }
     api.domains_dns_addHost(domain, record)
 
+
 args = get_args()
 
 domain = args.domain
-print("domain: %s" % domain)
 
-api = Api(username, api_key, username, ip_address, sandbox=args.sandbox, debug=args.debug)
+api = Api(username, api_key, username, ip_address,
+          sandbox=args.sandbox, debug=args.debug)
 
 if args.add:
     record_add(
@@ -78,4 +93,8 @@ elif args.delete:
     )
 elif args.list:
     for line in list_records():
-        print("\t%s \t%s\t%s -> %s" % (line["Type"], line["TTL"], line["Name"], line["Address"]))
+        print("\t%s \t%s\t%s -> %s" %
+              (line["Type"], line["TTL"], line["Name"], line["Address"]))
+elif args.json:
+    records = json.dumps([l for l in list_records()])
+    print(records)


### PR DESCRIPTION
The field EmailType must be without a number, so I removed the numbering
for that field in the _list_of_dictionaries_to_numbered_payload function.

As I'm submitting the PR, I realized that my editor added PEP8 formatting. I can remove that if you'd like. The main change is on line 247.