### PR TITLE
domains_dns_delHost: fix record key in comment

### DIFF
--- a/namecheap.py
+++ b/namecheap.py
@@ -395,8 +395,8 @@ class Api(object):
         Example:
 
         api.domains_dns_delHost('example.com', {
-            "RecordType": "A",
-            "HostName": "test",
+            "Type": "A",
+            "Name": "test",
             "Address": "127.0.0.1"
         })
         """


### PR DESCRIPTION
```py
api.domains_dns_delHost('example.com', {
            "RecordType": "A", <-- old
            "HostName": "test", <-- old
            "Type": "A", <-- new
            "Name": "test", <-- new
            "Address": "127.0.0.1"
        })
```
        
 This is just a simple documentation update. Additional work need to be done to ensure consistent usage of key ("RecordType" or"Type") throughout all the functions.