### PR TITLE
Add multiple host records in a single network request.

### DIFF
--- a/namecheap.py
+++ b/namecheap.py
@@ -387,6 +387,54 @@ class Api(object):
         })
         self._call("namecheap.domains.dns.setHosts", extra_payload)
 
+    def domains_dns_addHosts(self, domain, host_records):
+        """This method is absent in the original API. host_records is a list of
+        dicts. The advantage over `domains_dns_addHost` above is a single
+        network request rather than one for each record add having no knowledge
+        about the other records.
+
+        Example setting CNAME records for e.g. parking domains at bodis:
+
+        api.domains_dns_addHosts('example.com', [
+            {
+            "RecordType": "CNAME",
+            "HostName": "@",
+            "Address": "xyz.bodis.com",
+            "TTL": 1800
+            },
+            {
+            "RecordType": "CNAME",
+            "HostName": "*",
+            "Address": "xyz.bodis.com",
+            "TTL": 1800
+            },
+            {
+            "RecordType": "CNAME",
+            "HostName": "www",
+            "Address": "xyz.bodis.com",
+            "TTL": 1800
+            },
+        ])
+        """
+        host_records_remote = self.domains_dns_getHosts(domain)
+
+        print("Remote: %i" % len(host_records_remote))
+        
+        for host_record in host_records:
+            host_records_remote.append(host_record)
+
+        host_records_remote = [self._elements_names_fix(x) for x in host_records_remote]
+
+        print("To set: %i" % len(host_records_remote))
+
+        extra_payload = self._list_of_dictionaries_to_numbered_payload(host_records_remote)
+        sld, tld = domain.split(".")
+        extra_payload.update({
+            'SLD': sld,
+            'TLD': tld
+        })
+        self._call("namecheap.domains.dns.setHosts", extra_payload)
+
     def domains_dns_delHost(self, domain, host_record):
         """This method is absent in original API as well. It executes non-atomic
         remove operation over the host record which has the following Type,

--- a/namecheap_tests.py
+++ b/namecheap_tests.py
@@ -214,6 +214,89 @@ def test_domains_dns_addHost():
     ]
     assert_equal(hosts, expected_result)
 
+def test_domains_dns_addHosts():
+    api = Api(username, api_key, username, ip_address, sandbox=True)
+    domain_name = test_register_domain()
+    api.domains_dns_setHosts(
+        domain_name,
+        [{
+            'HostName': '@',
+            'RecordType': 'TXT',
+            'Address': 'specialtxtcode',
+            'TTL': '1800'
+        }]
+    )
+    api.domains_dns_addHosts(
+        domain_name,
+        [{
+            'RecordType': 'CNAME',
+            'HostName': '@',
+            'Address': 'xyz.bodis.com',
+            'TTL': '1800'
+        }, {
+            'RecordType': 'CNAME',
+            'HostName': '*',
+            'Address': 'xyz.bodis.com',
+            'TTL': '1800'
+        }, {
+            'RecordType': 'CNAME',
+            'HostName': 'www',
+            'Address': 'xyz.bodis.com',
+            'TTL': '1800'
+        }]
+    )
+
+    hosts = api.domains_dns_getHosts(domain_name)
+
+    # these might change
+    del hosts[0]['HostId']
+    del hosts[1]['HostId']
+
+    expected_result = [
+        {
+            'Name': '@',
+            'Address': 'xyz.bodis.com',
+            'TTL': '1800',
+            'Type': 'CNAME',
+            'MXPref': '10',
+            'AssociatedAppTitle': '',
+            'FriendlyName': '',
+            'IsActive': 'true',
+            'IsDDNSEnabled': 'false'
+        }, {
+            'Name': '*',
+            'Address': 'xyz.bodis.com',
+            'TTL': '1800',
+            'Type': 'CNAME',
+            'MXPref': '10',
+            'AssociatedAppTitle': '',
+            'FriendlyName': '',
+            'IsActive': 'true',
+            'IsDDNSEnabled': 'false'
+        }, {
+            'Name': 'www',
+            'Address': 'xyz.bodis.com',
+            'TTL': '1800',
+            'Type': 'CNAME',
+            'MXPref': '10',
+            'AssociatedAppTitle': '',
+            'FriendlyName': '',
+            'IsActive': 'true',
+            'IsDDNSEnabled': 'false'
+        }, {
+            'Name': '@',
+            'Address': 'specialtxtcode',
+            'TTL': '1800',
+            'Type': '@',
+            'MXPref': '10',
+            'AssociatedAppTitle': '',
+            'FriendlyName': '',
+            'IsActive': 'true',
+            'IsDDNSEnabled': 'false'
+        }
+    ]
+    assert_equal(hosts, expected_result)
+
 
 def test_domains_dns_bulkAddHosts():
     api = Api(username, api_key, username, ip_address, sandbox=True)


### PR DESCRIPTION
As with `domains_dns_addHost` but doing so for multiple records and using a single network request. Currently, every record is a network request. Adding parking records for bodis.com gets three CNAMES. Doing one request per record is inefficient. This solves that.